### PR TITLE
Fixed dropdown bug

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
 import "controllers"


### PR DESCRIPTION
Dropdown menu to switch from tasks to announcements page and vice versa was only expanding the dropdown once, then would need a reload in order to work. Found out that this is an issue caused by turbolinks, this stackoverflow post explains why: https://stackoverflow.com/questions/29018447/bootstrap-dropdown-stops-working-after-i-switch-pages-rails-4-2

To resolve this, I just removed turbolinks from our application.js file. 